### PR TITLE
[#38] Add cache bundler to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
 - 2.4
 script: ./_scripts/build_and_deploy.sh


### PR DESCRIPTION
As part of story #38 in Mingle.

Now output of bundle install was `18 seconds` instead of `60 seconds`.